### PR TITLE
MANIFEST.in: Add missing requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
+include requirements/base.txt
+include requirements/docs.txt
+include requirements/lint.txt
+include requirements/tests.txt
 include versioneer.py
 recursive-include saltfactories *.py


### PR DESCRIPTION
Building a Debian package fails when using the release tarball:

```
$ python3.8 setup.py clean
Traceback (most recent call last):
  File "setup.py", line 57, in <module>
    install_requires=parse_requirements(),
  File "setup.py", line 37, in parse_requirements
    for line in read(requirements_file_path).splitlines():
  File "setup.py", line 30, in read
    with codecs.open(file_path, encoding="utf-8") as rfh:
  File "/usr/lib/python3.8/codecs.py", line 905, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: 'requirements/base.txt'
```

Therefore include the files from the `requirements` directory into the
release tarball.