### PR TITLE
State Tree Temporary Files

### DIFF
--- a/.pylint-spelling-words
+++ b/.pylint-spelling-words
@@ -9,6 +9,7 @@ attr
 auth
 autodoc
 basename
+basepath
 bool
 booleans
 cli
@@ -118,6 +119,8 @@ sys
 sysinfo
 sysstats
 systemd
+tempfile
+tempfiles
 testname
 tmp
 tmpdir

--- a/.pylint-spelling-words
+++ b/.pylint-spelling-words
@@ -34,11 +34,13 @@ dunders
 ebuild
 env
 environ
+envs
 factorydaemonscriptbase
 favicon
 favicons
 fds
 formatter
+func
 funcname
 getsockname
 gettempdir
@@ -71,6 +73,7 @@ ordereddict
 os
 osx
 outputters
+pathlib
 pid
 png
 popen
@@ -88,8 +91,10 @@ repo
 ret
 returncode
 rst
+rtype
 saltapifactory
 saltcloudfactory
+saltenv
 saltfactories
 saltmaster
 saltmasterfactory

--- a/changelog/38.feature.rst
+++ b/changelog/38.feature.rst
@@ -1,0 +1,4 @@
+Temporary state tree management
+
+*  Add `temp_file` and `temp_directory` support as pytest helpers
+*  Add `SaltStateTree` and `SaltPillarTree` for easier temp files support

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,15 @@ import datetime
 import os
 import sys
 
+import pytest
 import sphinx_material_saltstack
+
+try:
+    pytest.helpers
+except AttributeError:
+    from pytest_helpers_namespace.plugin import HelpersRegistry
+
+    pytest.helpers = HelpersRegistry()
 
 try:
     docs_basepath = os.path.abspath(os.path.dirname(__file__))

--- a/docs/ref/saltfactories/utils/tempfiles.rst
+++ b/docs/ref/saltfactories/utils/tempfiles.rst
@@ -1,0 +1,5 @@
+.. automodule:: saltfactories.utils.tempfiles
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :no-undoc-members:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 pytest>=6.1.1
 attrs>=19.2.0
 pytest-tempdir>=2019.9.16
+pytest-helpers-namespace>=2020.3.24
 psutil
 pyzmq; python_version < '3.8'
 pyzmq<21.0.0; python_version >= '3.8'

--- a/saltfactories/factories/daemons/container.py
+++ b/saltfactories/factories/daemons/container.py
@@ -1,8 +1,12 @@
 """
-    saltfactories.factories.daemons.container
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+..
+    PYTEST_DONT_REWRITE
 
-    Container based factories
+
+saltfactories.factories.daemons.container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Container based factories
 """
 import atexit
 import logging

--- a/saltfactories/plugin.py
+++ b/saltfactories/plugin.py
@@ -9,6 +9,10 @@ import os
 import sys
 import tempfile
 
+import pytest
+
+import saltfactories.utils.tempfiles
+
 log = logging.getLogger(__name__)
 
 
@@ -55,3 +59,14 @@ def pytest_runtest_logfinish(nodeid):
     :param location: a triple of ``(filename, linenum, testname)``
     """
     log.debug("<<<<<<< END %s <<<<<<<", nodeid)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_load_initial_conftests(*_):
+    """
+    Register our pytest helpers
+    """
+    if "temp_directory" not in pytest.helpers:
+        pytest.helpers.register(saltfactories.utils.tempfiles.temp_directory, name="temp_directory")
+    if "temp_file" not in pytest.helpers:
+        pytest.helpers.register(saltfactories.utils.tempfiles.temp_file, name="temp_file")

--- a/saltfactories/utils/tempfiles.py
+++ b/saltfactories/utils/tempfiles.py
@@ -1,0 +1,181 @@
+"""
+saltfactories.utils.tempfiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Temporary files utilities
+"""
+import logging
+import os
+import pathlib
+import shutil
+import tempfile
+import textwrap
+from contextlib import contextmanager
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.helpers.register
+@contextmanager
+def temp_directory(name=None, basepath=None):
+    """
+    This helper creates a temporary directory.
+    It should be used as a context manager which returns the temporary directory path, and, once out of context,
+    deletes it.
+
+    :keyword str name:
+        The name of the directory to create
+    :keyword basepath name:
+        The base path of where to create the directory. Defaults to :py:func:`~tempfile.gettempdir`
+    :rtype: pathlib.Path
+
+    Can be directly imported and used:
+
+    .. code-block:: python
+
+        from saltfactories.utils.tempfiles import temp_directory
+
+
+        def test_func():
+
+            with temp_directory() as temp_path:
+                assert temp_path.is_dir()
+
+            assert not temp_path.is_dir() is False
+
+    Or, it can be used as a pytest helper function:
+
+    .. code-block:: python
+
+        import pytest
+
+
+        def test_blah():
+            with pytest.helpers.temp_directory() as temp_path:
+                assert temp_path.is_dir()
+
+            assert not temp_path.is_dir() is False
+    """
+    if basepath is None:
+        basepath = pathlib.Path(tempfile.gettempdir())
+    try:
+        if name is not None:
+            directory_path = basepath / name
+        else:
+            directory_path = pathlib.Path(tempfile.mkdtemp(dir=str(basepath)))
+
+        if not directory_path.is_dir():
+            directory_path.mkdir(parents=True)
+            log.debug("Created temp directory: %s", directory_path)
+
+        yield directory_path
+    finally:
+        created_directory = directory_path
+        while True:
+            print(1, basepath, created_directory)
+            if str(created_directory) == str(basepath):
+                break
+            if not any(created_directory.iterdir()):
+                shutil.rmtree(str(created_directory), ignore_errors=True)
+                log.debug("Deleted temp directory: %s", created_directory)
+            else:
+                log.debug("Not deleting %s because it's not empty", created_directory)
+            created_directory = created_directory.parent
+
+
+@pytest.helpers.register
+@contextmanager
+def temp_file(name=None, contents=None, directory=None, strip_first_newline=True):
+    """
+    This helper creates a temporary file. It should be used as a context manager
+    which returns the temporary file path, and, once out of context, deletes it.
+
+    :keyword str name:
+        The temporary file name
+    :keyword str contents:
+        The contents of the temporary file
+    :keyword str,pathlib.Path directory:
+        The directory where to create the temporary file. Defaults to the value of :py:func:`~tempfile.gettempdir`
+    :keyword bool strip_first_newline:
+        Either strip the initial first new line char or not.
+
+    :rtype: pathlib.Path
+
+    Can be directly imported and used:
+
+    .. code-block:: python
+
+        from saltfactories.utils.tempfiles import temp_file
+
+
+        def test_func():
+
+            with temp_file(name="blah.txt") as temp_path:
+                assert temp_path.is_file()
+
+            assert not temp_path.is_file() is False
+
+    Or, it can be used as a pytest helper function:
+
+    .. code-block:: python
+
+        import pytest
+
+
+        def test_blah():
+            with pytest.helpers.temp_file("blah.txt") as temp_path:
+                assert temp_path.is_file()
+
+            assert not temp_path.is_file() is False
+    """
+    if directory is None:
+        directory = tempfile.gettempdir()
+
+    if not isinstance(directory, pathlib.Path):
+        directory = pathlib.Path(str(directory))
+
+    if name is not None:
+        file_path = directory / name
+    else:
+        handle, file_path = tempfile.mkstemp(dir=str(directory))
+        os.close(handle)
+        file_path = pathlib.Path(file_path)
+
+    # Find out if we were given sub-directories on `name`
+    create_directories = file_path.parent.relative_to(directory)
+
+    if create_directories:
+        with temp_directory(create_directories, basepath=directory):
+            with _write_or_touch(file_path, contents, strip_first_newline=strip_first_newline):
+                yield file_path
+    else:
+        with _write_or_touch(file_path, contents, strip_first_newline=strip_first_newline):
+            yield file_path
+
+
+@contextmanager
+def _write_or_touch(file_path, contents, strip_first_newline=True):
+    try:
+        if contents is not None:
+            if contents:
+                if contents.startswith("\n") and strip_first_newline:
+                    contents = contents[1:]
+                file_contents = textwrap.dedent(contents)
+            else:
+                file_contents = contents
+
+            file_path.write_text(file_contents)
+            log_contents = "{0} Contents of {1}\n{2}\n{3} Contents of {1}".format(
+                ">" * 6, file_path, file_contents, "<" * 6
+            )
+            log.debug("Created temp file: %s\n%s", file_path, log_contents)
+        else:
+            file_path.touch()
+            log.debug("Touched temp file: %s", file_path)
+        yield
+    finally:
+        if file_path.exists():
+            file_path.unlink()
+            log.debug("Deleted temp file: %s", file_path)

--- a/tests/functional/utils/test_tempfiles.py
+++ b/tests/functional/utils/test_tempfiles.py
@@ -1,0 +1,118 @@
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+from saltfactories.utils import tempfiles
+
+
+@pytest.mark.parametrize("name", ["foo", "foo/bar"])
+def test_temp_directory_with_name(name):
+    try:
+        expected_path = pathlib.Path(tempfile.gettempdir()) / name
+        assert expected_path.is_dir() is False
+        with tempfiles.temp_directory(name=name) as tpath:
+            assert tpath.is_dir()
+            assert tpath == expected_path
+        assert expected_path.is_dir() is False
+    finally:
+        shutil.rmtree(str(expected_path), ignore_errors=True)
+
+
+def test_temp_directory_without_name():
+    try:
+        expected_parent_path = pathlib.Path(tempfile.gettempdir())
+        with tempfiles.temp_directory() as tpath:
+            assert tpath.is_dir()
+            assert tpath.parent == expected_parent_path
+        assert tpath.is_dir() is False
+    finally:
+        shutil.rmtree(str(tpath), ignore_errors=True)
+
+
+def test_temp_directory_with_basepath(tmp_path):
+    with tempfiles.temp_directory(basepath=tmp_path) as tpath:
+        assert tpath.is_dir()
+        assert str(tpath.parent) == str(tmp_path)
+    assert tpath.is_dir() is False
+    assert tmp_path.is_dir() is True
+
+
+@pytest.mark.parametrize("name", ["foo.txt", "foo/bar.txt"])
+def test_temp_file_with_name(tmp_path, name):
+    expected_path = tmp_path / name
+    assert expected_path.is_file() is False
+    with tempfiles.temp_file(name=name, directory=tmp_path) as tpath:
+        assert tpath.is_file()
+        assert str(tpath) == str(expected_path)
+    assert expected_path.is_file() is False
+
+
+def test_temp_file_without_name(tmp_path):
+    expected_parent_path = tmp_path
+    with tempfiles.temp_file(directory=tmp_path) as tpath:
+        assert tpath.is_file()
+        assert str(tpath.parent) == str(expected_parent_path)
+    assert tpath.is_file() is False
+
+
+@pytest.mark.parametrize("name", ["foo.txt", "foo/bar.txt"])
+def test_temp_file_with_name_no_directory(name):
+    try:
+        expected_path = pathlib.Path(tempfile.gettempdir()) / name
+        assert expected_path.is_file() is False
+        with tempfiles.temp_file(name=name) as tpath:
+            assert tpath.is_file()
+            assert str(tpath) == str(expected_path)
+        assert expected_path.is_file() is False
+    finally:
+        shutil.rmtree(str(expected_path), ignore_errors=True)
+
+
+def test_temp_file_without_name_no_directory():
+    try:
+        expected_parent_path = pathlib.Path(tempfile.gettempdir())
+        with tempfiles.temp_file() as tpath:
+            assert tpath.is_file()
+            assert str(tpath.parent) == str(expected_parent_path)
+        assert tpath.is_file() is False
+    finally:
+        shutil.rmtree(str(tpath), ignore_errors=True)
+
+
+def test_temp_file_does_not_delete_non_empty_directories(tmp_path):
+    expected_parent_path = tmp_path
+    level1_path = expected_parent_path / "level1"
+    level2_path = level1_path / "level2"
+    assert not level1_path.is_dir()
+    assert not level2_path.is_dir()
+    with tempfiles.temp_file("level1/foo.txt", directory=expected_parent_path) as tpath1:
+        assert tpath1.is_file()
+        assert level1_path.is_dir()
+        assert not level2_path.is_dir()
+        with tempfiles.temp_file("level1/level2/foo.txt", directory=expected_parent_path) as tpath2:
+            assert tpath2.is_file()
+            assert level1_path.is_dir()
+            assert level2_path.is_dir()
+        assert not tpath2.is_file()
+        assert not level2_path.is_dir()
+        assert tpath1.is_file()
+        assert level1_path.is_dir()
+    assert not level1_path.is_dir()
+    assert not level2_path.is_dir()
+
+
+@pytest.mark.parametrize("strip_first_newline", [True, False])
+def test_temp_file_contents(strip_first_newline):
+    contents = """
+     These are the contents, first line
+      Second line
+    """
+    if strip_first_newline:
+        expected_contents = "These are the contents, first line\n Second line\n"
+    else:
+        expected_contents = "\nThese are the contents, first line\n Second line\n"
+    with tempfiles.temp_file(contents=contents, strip_first_newline=strip_first_newline) as tpath:
+        assert tpath.is_file()
+        assert tpath.read_text() == expected_contents

--- a/tests/integration/factories/daemons/master/test_master.py
+++ b/tests/integration/factories/daemons/master/test_master.py
@@ -46,6 +46,11 @@ def salt_key(master):
     return master.get_salt_key_cli()
 
 
+@pytest.fixture
+def salt_call(minion):
+    return minion.get_salt_call_cli()
+
+
 def test_master(master):
     assert master.is_running()
 
@@ -142,3 +147,13 @@ def test_exit_status_unknown_user(salt_factories):
 
     assert exc.value.exitcode == salt.defaults.exitcodes.EX_NOUSER, str(exc.value)
     assert "The user is not available." in exc.value.stderr, str(exc.value)
+
+
+def test_state_tree(master, salt_call):
+    sls_contents = """
+    test:
+      test.succeed_without_changes
+    """
+    with master.state_tree.base.temp_file("foo.sls", sls_contents):
+        ret = salt_call.run("state.sls", "foo")
+        assert ret.exitcode == 0

--- a/tests/integration/factories/daemons/minion/test_minion.py
+++ b/tests/integration/factories/daemons/minion/test_minion.py
@@ -64,3 +64,13 @@ def test_salt_call_exception_handling_doesnt_timeout(minion, salt_call_cli):
         "test.raise_exception", "OSError", "2", "No such file or directory", "/tmp/foo.txt"
     )
     assert ret.exitcode == 1, ret
+
+
+def test_state_tree(minion, salt_call_cli):
+    sls_contents = """
+    test:
+      test.succeed_without_changes
+    """
+    with minion.state_tree.base.temp_file("foo.sls", sls_contents):
+        ret = salt_call_cli.run("--local", "state.sls", "foo")
+        assert ret.exitcode == 0

--- a/tests/integration/factories/daemons/proxy/test_proxy_minion.py
+++ b/tests/integration/factories/daemons/proxy/test_proxy_minion.py
@@ -70,3 +70,13 @@ def test_proxy_minion_salt_call(proxy_minion, salt_call_cli):
     ret = salt_call_cli.run("--proxyid={}".format(proxy_minion.id), "test.ping")
     assert ret.exitcode == 0, ret
     assert ret.json is True
+
+
+def test_state_tree(proxy_minion, salt_call_cli):
+    sls_contents = """
+    test:
+      test.succeed_without_changes
+    """
+    with proxy_minion.state_tree.base.temp_file("foo.sls", sls_contents):
+        ret = salt_call_cli.run("--local", "state.sls", "foo")
+        assert ret.exitcode == 0


### PR DESCRIPTION
*  Add `temp_file` and `temp_directory` support as pytest helpers 
*  Add `SaltStateTree` and `SaltPillarTree` for easier temp files support