### PR TITLE
Mock docker import in test_missing_requests_library

### DIFF
--- a/tests/unit/factories/daemons/test_container.py
+++ b/tests/unit/factories/daemons/test_container.py
@@ -18,6 +18,9 @@ def test_missing_docker_library():
 
 def test_missing_requests_library():
     with mock.patch(
+        "saltfactories.daemons.container.HAS_DOCKER",
+        new_callable=mock.PropertyMock(return_value=True),
+    ), mock.patch(
         "saltfactories.daemons.container.HAS_REQUESTS",
         new_callable=mock.PropertyMock(return_value=False),
     ):


### PR DESCRIPTION
The test `test_missing_requests_library` will fail if docker is not installed:

```
>           assert str(exc.value) == "The requests python library was not found installed"
E           AssertionError: assert 'The docker p...und installed' == 'The requests...und installed'
E             - The requests python library was not found installed
E             ?      -------
E             + The docker python library was not found installed
E             ?     +++++
```

So also mock the import of the docker Python module.