### PR TITLE
Support running tests locally

### DIFF
--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import sys
 
@@ -21,6 +22,8 @@ def cmdline_ids(value):
     ids=cmdline_ids,
 )
 def test_salt_factories_cli(cmdline):
+    if not shutil.which(cmdline[0]):
+        pytest.skip("binary {} not found".format(cmdline[0]))
     ret = subprocess.run(
         cmdline,
         stdout=subprocess.PIPE,
@@ -41,6 +44,8 @@ def test_salt_factories_cli(cmdline):
     ids=cmdline_ids,
 )
 def test_salt_factories_cli_show_help(cmdline):
+    if not shutil.which(cmdline[0]):
+        pytest.skip("binary {} not found".format(cmdline[0]))
     ret = subprocess.run(
         cmdline,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
When running the tests locally (e.g. during Debian package build), the binary `salt-factories` is not available in the search path yet. Therefore `test_salt_factories_cli` will fail:

```
FileNotFoundError: [Errno 2] No such file or directory: 'salt-factories'
```

So skip the test case if the binary cannot be found.