### PR TITLE
Relax matching expression for test_basic_sys_stats

### DIFF
--- a/tests/functional/test_sys_stats.py
+++ b/tests/functional/test_sys_stats.py
@@ -21,7 +21,7 @@ def test_basic_sys_stats(pytester):
             "* PASSED*",
             "* Processes Statistics *",
             "* System  -  CPU: * %   MEM: * % (Virtual Memory)*",
-            "* Test Suite Run  -  CPU: * %   MEM: * % (RSS)",
+            "* Test Suite Run  -  CPU: * %   MEM: * % (RSS)*",
             "* 1 passed in *",
         ]
     )
@@ -42,7 +42,7 @@ def test_basic_sys_stats_uss(pytester):
             "* PASSED*",
             "* Processes Statistics *",
             "* System  -  CPU: * %   MEM: * % (Virtual Memory)*",
-            "* Test Suite Run  -  CPU: * %   MEM: * % (USS)",
+            "* Test Suite Run  -  CPU: * %   MEM: * % (USS)*",
             "* 1 passed in *",
         ]
     )


### PR DESCRIPTION
When running the functional tests `test_basic_sys_stats` and `test_basic_sys_stats_uss` as autopkgtest in Debian, the output of the pytest run is more verbose than these test cases expect:

```
  ...  Test Suite Run  -  CPU:   0.00 %   MEM:   0.17 % (RSS)   MEM SUM:   0.18 % (RSS)   CHILD PROCS: 4
```

Enhance the match to allow further output after `(RSS)`.