### PR TITLE
remove transport kwarg from get_event

### DIFF
--- a/src/saltfactories/utils/saltext/engines/pytest_engine.py
+++ b/src/saltfactories/utils/saltext/engines/pytest_engine.py
@@ -129,7 +129,6 @@ class PyTestEventForwardEngine:
             with salt.utils.event.get_event(
                 self.role,
                 sock_dir=opts["sock_dir"],
-                transport=opts["transport"],
                 opts=opts,
                 listen=True,
             ) as eventbus:


### PR DESCRIPTION
In anticipation of https://github.com/saltstack/salt/issues/61275