### PR TITLE
Add ``--sys-info-and-exit`` CLI flag support.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    # Not self hosted but actionlint still does not have a
+    # release out supporting it
+    - macos-13-large
+    - macos-13-xlarge

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Set Cache Key
       run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
     - uses: actions/cache@v4
@@ -52,10 +52,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.9 For Nox
+    - name: Set up Python 3.11 For Nox
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install Nox
       run: |
@@ -82,10 +82,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9 For Nox
+    - name: Set up Python 3.11 For Nox
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install Nox
       run: |
@@ -199,6 +199,7 @@ jobs:
         pytest-version:
           - "7.3.0"
           - "7.4.0"
+          - "8.0.0rc2"
 
     steps:
     - uses: actions/checkout@v4
@@ -284,6 +285,7 @@ jobs:
         pytest-version:
           - "7.3.0"
           - "7.4.0"
+          - "8.0.0rc2"
 
     steps:
     - uses: actions/checkout@v4
@@ -368,8 +370,11 @@ jobs:
         pytest-version:
           - "7.3.0"
           - "7.4.0"
+          - "8.0.0rc2"
         exclude:
           - {"python-version": "3.10", "salt-version": "3005.0"}
+          - {"pytest-version": "8.0.0rc2", "salt-version": "3005.0"}
+          - {"pytest-version": "8.0.0rc2", "python-version": "3.7"}
 
     steps:
     - uses: actions/checkout@v4
@@ -452,7 +457,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install Nox
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -268,10 +268,10 @@ jobs:
 
 
   MacOS:
-    runs-on: macOS-latest
+    runs-on: ${{ github.event.repository.fork && 'macos-latest' || 'macos-13-large' }}
     needs: Pre-Commit
 
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false

--- a/.pylintrc
+++ b/.pylintrc
@@ -618,5 +618,5 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/changelog/173.improvement.rst
+++ b/changelog/173.improvement.rst
@@ -1,0 +1,1 @@
+Add ``--sys-info-and-exit`` which basically prints the system information and exit. Doesn't run any tests.

--- a/changelog/173.trivial.rst
+++ b/changelog/173.trivial.rst
@@ -1,0 +1,1 @@
+Switch pipelines to use Python 3.11 and start testing Pytest 8.0.0rc2

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,7 +118,7 @@ def session_run_always(session, *command, **kwargs):
             session._runner.global_config.install_only = old_install_only_value
 
 
-@nox.session(python=("3", "3.6", "3.7", "3.8", "3.9", "3.10"))
+@nox.session(python=("3", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"))
 def tests(session):
     """
     Run tests.
@@ -293,6 +293,9 @@ def tests(session):
 
 
 def _lint(session, rcfile, extra_args, paths):
+    python_version_info = _get_session_python_version_info(session)
+    if python_version_info < (3, 11):
+        session.error("Please run with nox installed under Python 3.11")
     if SKIP_REQUIREMENTS_INSTALL is False:
         python_version_info = _get_session_python_version_info(session)
         salt_requirements = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ builtins = [
   "__salt_system_encoding__",
 ]
 # Group violations by containing file.
-format = "grouped"
 ignore = [
   "ANN",     # annotations
   "PTH",     # Replace with pathlib.Path

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,6 +1,6 @@
 -r base.txt
 -r tests.txt
-pylint==2.14.5
+pylint==3.0.3
 pyenchant
 black; python_version >= '3.7'
 reorder-python-imports; python_version >= '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License

--- a/tests/functional/test_sys_info.py
+++ b/tests/functional/test_sys_info.py
@@ -1,5 +1,5 @@
 """
-Tests related to system information reports enabled by the `--sys-info` flag..
+Tests related to system information reports.
 """
 import pytest
 
@@ -44,3 +44,23 @@ def test_no_sysinfo(pytester):
             "* 1 passed in *",
         ]
     )
+
+
+def test_sysinfo_and_exit(pytester):
+    pytester.makepyfile(
+        """
+        def test_one():
+            assert True
+        """
+    )
+    res = pytester.runpytest("-vv", "--sys-info-and-exit")
+    res.stdout.fnmatch_lines(
+        [
+            "*>> System Information >>*",
+            "*-- Salt Versions Report --*",
+            "*-- System Grains Report --*",
+            "*<< System Information <<*",
+        ]
+    )
+    res.stdout.no_fnmatch_line("collect*")
+    res.stdout.no_fnmatch_line("INTERNALERROR*")


### PR DESCRIPTION
Basically prints the system information and exits. Doesn't run any tests.

Fixes #173