### PR TITLE
Fix compatibility with Pytest 8.4+

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,7 +42,7 @@ jobs:
         pre-commit run --show-diff-on-failure --color=always --all-files
 
   Docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: Pre-Commit
 
     timeout-minutes: 10

--- a/changelog/187.bugfix.rst
+++ b/changelog/187.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed compatibility with Pytest 8.4+


### PR DESCRIPTION
### What does this PR do?
- Fixes test suite installation of Salt (see https://github.com/saltstack/salt/issues/67973)
- Accounts for new Pytest internals in 8.4, fixing compatibility with it.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/pytest-salt-factories/issues/187

### Previous Behavior
Any test run with `pytest-salt-factories` and `pytest>=8.4` crashes hard

### New Behavior
Works as expected
